### PR TITLE
fix package.module

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.6",
   "description": "QR code scanner component for React apps",
   "main": "dist/index.js",
-  "module": "dist/index.es.js",
+  "module": "dist/index.esm.js",
   "scripts": {
     "build": "rollup -c"
   },


### PR DESCRIPTION
The result of the build is dist/index.esm.js, while the module field in package.json is dist/index.es.js. This will cause a failure when building with Vite.